### PR TITLE
fix: `debug` log level for `refresh()` is too noisy

### DIFF
--- a/lib/exclusive-lock.js
+++ b/lib/exclusive-lock.js
@@ -126,7 +126,7 @@ class ExclusiveLock extends EventEmitter {
     this.cache_connection
       .pexpire(this.key, this.lock_ttl_ms)
       .then(() => {
-        this.log.debug('%s lock refreshed to %sms', this.key, this.lock_ttl_ms)
+        this.log.trace('%s lock refreshed to %sms', this.key, this.lock_ttl_ms)
         this.emit('refreshed', {
           key: this.key
         , lock_ttl_ms: this.lock_ttl_ms


### PR DESCRIPTION
This increases the log level for the refresh function to
use `trace`.  This way, calling application can see more
useful information if they happen to be using `debug`.

Fixes: #4