### PR TITLE
chore(lib)!: Change the return value for `inspect`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -88,30 +88,33 @@ encouter errors asynchronously.  See the [`error`](#error) event for details on 
   * `lock_refres_ms` [`<Number>`][] - Optional. specify a time in milliseconds for refreshing the lock on an interval. **Default: 1000**
   * `lock_contents` [`<String>`][] - Optional. Specify the string contents to put in the lock file, e.g. a server/instance name.
 
-  Throws: [`<Error>`][] for validation errors
+  *Throws*: [`<Error>`][] for validation errors
 
 ### `acquire()`
 
 Attempts to exclusively acquire a lock based on the given `name`. If multiple
 instances are competing, only 1 will win the lock.
 
-Returns: `Promise<Boolean>` if the lock was a success \
-Emits: [`acquired`](#acquired)
+*Returns*: `Promise<Boolean>` if the lock was a success \
+*Emits*: [`acquired`](#acquired)
 
 ### `inspect()`
 
-Returns the contents of the lock. Useful if `lock_contents` was used to store
-valuable information in the lock.
+Returns an object containing the remaining TTL (if any) on the lock, and the serialized lock contents. Useful if `lock_contents` was used to store
+valuable information in the lock, or to analyze the TTL. Any client can inspect
+the lock regardless of who acquired it.
 
-Returns: `Promise<Object|Number|Boolean|String>` The contents of the lock
+**If there is no lock, `null` is returned**
 
+*Returns*: `Promise<Object<lock_ttl_ms: Number, lock_contents: Object|Number|Boolean|String>>` An object containing the remaining TTL (in milliseconds), plus the contents of the lock \
+*Throws*: [`<Error>`][] for cache store `pipeline` errors
 ### `release()`
 
 Unlock based on `name`.  Idempotent.  Instances that do not have the lock will
 be a no-op.
 
-Returns: `Promise<undefined>` \
-Emits: [`released`](#released)
+*Returns*: `Promise<undefined>` \
+*Emits*: [`released`](#released)
 
 ## Events
 

--- a/lib/exclusive-lock.js
+++ b/lib/exclusive-lock.js
@@ -115,9 +115,37 @@ class ExclusiveLock extends EventEmitter {
     return this.acquired
   }
 
-  inspect() {
-    if (!this.acquired) return
-    return this.cache_connection.get(this.key)
+  async inspect() {
+    const results = await this.cache_connection
+      .multi()
+      .get(this.key)
+      .pttl(this.key)
+      .exec() ?? []
+
+    const [val_err, val] = results[0] ?? []
+    const [ttl_err, ttl_ms] = results[1] ?? []
+
+    if (val_err) {
+      this.log.error({
+        key: this.key
+      , err: val_err
+      }, 'Error during inspect while getting the key: %s', val_err)
+      throw val_err
+    }
+    if (ttl_err) {
+      this.log.error({
+        key: this.key
+      , err: ttl_err
+      }, 'Error during inspect while getting the TTL: %s', ttl_err)
+      throw ttl_err
+    }
+    // Return null only if there is no lock file
+    if (val === null) return null
+
+    return {
+      lock_ttl_ms: ttl_ms
+    , lock_contents: val
+    }
   }
 
   #refresh() {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "check-coverage": true,
     "output-file": ".tap-output",
     "files": [
-      "test/unit",
       "test/integration"
     ],
     "coverage-report": [


### PR DESCRIPTION
The `inspect` function would be more helpful if it also
returned the TTL as well as the contents. Also, do NOT
require the lock to be held in order to inspect. This way,
other clients can view the contents if there is useful
metadata stored in the lock.

BREAKING CHANGE: The function now returns a static object with
properties for TTL and contents

BREAKING CHANGE: `acquire` is no longer required to `inspect`

Fixes: #6